### PR TITLE
fix: コンストラクタを追加

### DIFF
--- a/Source/TaskSystemBP/Public/TSBTaskResult.h
+++ b/Source/TaskSystemBP/Public/TSBTaskResult.h
@@ -42,6 +42,9 @@ struct TASKSYSTEMBP_API FTSBTaskResult_String
 
 	UPROPERTY()
 	FString ResultValue;
+
+	FTSBTaskResult_String() = default; // デフォルトコンストラクタ
+	FTSBTaskResult_String(const FString& InValue) : ResultValue(InValue) {}
 };
 
 USTRUCT()
@@ -51,6 +54,9 @@ struct TASKSYSTEMBP_API FTSBTaskResult_Int
 
 	UPROPERTY()
 	int32 ResultValue;
+
+	FTSBTaskResult_Int() : ResultValue(0) {} // デフォルトコンストラクタ
+	FTSBTaskResult_Int(const int32 InValue) : ResultValue(InValue) {}
 };
 
 USTRUCT()
@@ -60,6 +66,9 @@ struct TASKSYSTEMBP_API FTSBTaskResult_Float
 
 	UPROPERTY()
 	float ResultValue;
+
+	FTSBTaskResult_Float() : ResultValue(0.0f) {} // デフォルトコンストラクタ
+	FTSBTaskResult_Float(const float InValue) : ResultValue(InValue) {}
 };
 
 USTRUCT()
@@ -69,6 +78,9 @@ struct TASKSYSTEMBP_API FTSBTaskResult_Bool
 
 	UPROPERTY()
 	bool ResultValue;
+
+	FTSBTaskResult_Bool() : ResultValue(false) {} // デフォルトコンストラクタ
+	FTSBTaskResult_Bool(const bool InValue) : ResultValue(InValue) {}
 };
 
 UCLASS()


### PR DESCRIPTION
エラーメッセージ no matching constructor for initialization of 'FTSBTaskResult_Bool' が示す通り、 FInstancedStruct::Make<ResultStructType>(InValue) は ResultStructType のコンストラクタを呼び出してインスタンスを生成しようとします。

具体的には、TaskSystemBP::MakeTaskResult<FTSBTaskResult_Bool>(InTaskResult) が呼ばれると、内部で FInstancedStruct::Make<FTSBTaskResult_Bool>(InTaskResult) が実行され、これは FTSBTaskResult_Bool のコンストラクタ FTSBTaskResult_Bool(const bool&) を探します。

しかし、提示されたコードの FTSBTaskResult_Bool (および他の FTSBTaskResult_XXX 構造体) には、対応する型の値 (bool, float, int32, FString) を引数として受け取るコンストラクタが定義されていません。そのため、 FInstancedStruct::Make は適切なコンストラクタを見つけられず、コンパイルエラーが発生しています。

解決策:

各 FTSBTaskResult_XXX 構造体に、対応する型の値を受け取って ResultValue メンバを初期化するコンストラクタを追加します。また、デフォルトコンストラクタも明示的に定義しておくと良いでしょう。