### PR TITLE
feat: MakeTaskEvent, MakePipeをPureからCallableへ

### DIFF
--- a/Source/TaskSystemBP/Public/TSBFunctionLibrary.h
+++ b/Source/TaskSystemBP/Public/TSBFunctionLibrary.h
@@ -72,10 +72,10 @@ public:
 	// UFUNCTION(BlueprintCallable, Category = "TaskSystem")
 	// static FTSBTaskHandle Any(const TArray<FTSBTaskHandle>& Tasks);
 
-	UFUNCTION(BlueprintPure, Category = "TaskSystem", meta = (AutoCreateRefTerm = "InDebugName"))
+	UFUNCTION(BlueprintCallable, Category = "TaskSystem", meta = (AutoCreateRefTerm = "InDebugName"))
 	static FTSBTaskHandle MakeTaskEvent(const FString& InDebugName);
 
-	UFUNCTION(BlueprintPure, Category = "TaskSystem", meta = (AutoCreateRefTerm = "InDebugName"))
+	UFUNCTION(BlueprintCallable, Category = "TaskSystem", meta = (AutoCreateRefTerm = "InDebugName"))
 	static FTSBPipe MakePipe(const FString& InDebugName);
 
 	// UFUNCTION(BlueprintPure, Category = "TaskSystem")


### PR DESCRIPTION
MakeTaskEvent, MakePipeは現在Pureノードなので、メンバ変数等に格納するのが必須になっている
実行ピンつきノードにしておけば、そのノードに保存されるので、保存用メンバ変数を作らずに利用できる場合が生まれます（下記画像参照）
![image](https://github.com/user-attachments/assets/0abcedf6-3fe5-431b-8cd3-0e8aabbffb12)

何か情報を取り出すだけなら、pureでも良いが、インスタンス的に何かを作って今後それをずっと利用する、みたいな機能の場合は、一般にpureではなくcallableのほうが良いんじゃないかと思っていますがどうでしょうか。